### PR TITLE
expose permutation and columns to public

### DIFF
--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -1549,8 +1549,8 @@ pub struct ConstraintSystem<F: Field> {
     pub(crate) instance_queries: Vec<(Column<Instance>, Rotation)>,
     pub(crate) fixed_queries: Vec<(Column<Fixed>, Rotation)>,
 
-    // Permutation argument for performing equality constraints
-    pub(crate) permutation: permutation::Argument,
+    /// Permutation argument for performing equality constraints
+    pub permutation: permutation::Argument,
 
     // Vector of lookup arguments, where each corresponds to a sequence of
     // input expressions and a sequence of table expressions involved in the lookup.

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -24,7 +24,7 @@ use std::io;
 #[derive(Debug, Clone)]
 pub struct Argument {
     /// A sequence of columns involved in the argument.
-    pub(super) columns: Vec<Column<Any>>,
+    pub columns: Vec<Column<Any>>,
 }
 
 impl Argument {


### PR DESCRIPTION
This is needed to get necessary permutation information from halo2 into sirius.